### PR TITLE
feat : 로그 엔티티 관계설정 변경

### DIFF
--- a/src/_common/entities/audit-log.entity.ts
+++ b/src/_common/entities/audit-log.entity.ts
@@ -1,9 +1,6 @@
 import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { User } from './user.entitiy';
 import { Workspace } from './workspace.entity';
-import { Board } from './board.entity';
-import { Board_Column } from './board-column.entity';
-import { Card } from './card.entity';
 import ActionType from '../utils/action-type';
 
 @Entity('audit_logs')
@@ -23,15 +20,9 @@ export class Audit_log {
   @ManyToOne(() => User, (user) => user.audit_logs)
   user: User;
 
-  @ManyToOne(() => Workspace, (workspace) => workspace.audit_logs)
+  @ManyToOne(() => Workspace, (workspace) => workspace.audit_logs, {
+    onDelete: 'CASCADE',
+    nullable: false,
+  })
   workspace: Workspace;
-
-  @ManyToOne(() => Board, (board) => board.audit_logs)
-  board: Board;
-
-  @ManyToOne(() => Board_Column, (column) => column.audit_logs)
-  board_column: Board_Column;
-
-  @ManyToOne(() => Card, (card) => card.audit_logs)
-  card: Card;
 }

--- a/src/_common/entities/board-column.entity.ts
+++ b/src/_common/entities/board-column.entity.ts
@@ -9,7 +9,6 @@ import {
 } from 'typeorm';
 import { Board } from './board.entity';
 import { Card } from './card.entity';
-import { Audit_log } from './audit-log.entity';
 
 @Entity('board_columns')
 export class Board_Column {
@@ -38,7 +37,4 @@ export class Board_Column {
     cascade: true,
   })
   cards: Card[];
-
-  @OneToMany(() => Audit_log, (log) => log.board_column)
-  audit_logs: Audit_log[];
 }

--- a/src/_common/entities/board.entity.ts
+++ b/src/_common/entities/board.entity.ts
@@ -50,7 +50,4 @@ export class Board {
     cascade: true,
   })
   board_columns: Board_Column[];
-
-  @OneToMany(() => Audit_log, (log) => log.board)
-  audit_logs: Audit_log[];
 }

--- a/src/_common/entities/card.entity.ts
+++ b/src/_common/entities/card.entity.ts
@@ -57,7 +57,4 @@ export class Card {
   })
   board_column: Board_Column;
   column: any;
-
-  @OneToMany(() => Audit_log, (log) => log.card)
-  audit_logs: Audit_log[];
 }

--- a/src/_common/entities/membership.entity.ts
+++ b/src/_common/entities/membership.entity.ts
@@ -22,6 +22,7 @@ export class Membership {
   updated_at: Date;
 
   @ManyToOne(() => Workspace, (workspace) => workspace.memberships, {
+    onDelete: 'CASCADE',
     nullable: true,
   })
   workspace: Workspace;

--- a/src/_common/entities/user.entitiy.ts
+++ b/src/_common/entities/user.entitiy.ts
@@ -100,6 +100,9 @@ export class User {
   })
   payments: Payment[];
 
-  @OneToMany(() => Audit_log, (log) => log.user)
+  @OneToMany(() => Audit_log, (log) => log.user, {
+    cascade: false,
+    nullable: true,
+  })
   audit_logs: Audit_log[];
 }

--- a/src/_common/entities/workspace.entity.ts
+++ b/src/_common/entities/workspace.entity.ts
@@ -56,6 +56,9 @@ export class Workspace {
   })
   memberships: Membership[];
 
-  @OneToMany(() => Audit_log, (log) => log.workspace)
+  @OneToMany(() => Audit_log, (log) => log.workspace, {
+    cascade: true,
+    nullable: false,
+  })
   audit_logs: Audit_log[];
 }

--- a/src/audit-logs/audit-logs.module.ts
+++ b/src/audit-logs/audit-logs.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AuditLogsController } from './audit-logs.controller';
 import { AuditLogsService } from './audit-logs.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Audit_log])],
   controllers: [AuditLogsController],
-  providers: [AuditLogsService]
+  providers: [AuditLogsService],
 })
 export class AuditLogsModule {}

--- a/src/audit-logs/audit-logs.service.ts
+++ b/src/audit-logs/audit-logs.service.ts
@@ -1,4 +1,133 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
+import ActionType from 'src/_common/utils/action-type';
+import { Repository } from 'typeorm';
 
 @Injectable()
-export class AuditLogsService {}
+export class AuditLogsService {
+  constructor(
+    @InjectRepository(Audit_log)
+    private auditLogRepository: Repository<Audit_log>
+  ) {}
+
+  async inviteMemberLog(
+    workspaceId: number,
+    inviterUserId: number,
+    inviterUserName: string,
+    invitedUserName: string
+  ): Promise<Audit_log> {
+    const newLog = this.auditLogRepository.create({
+      workspace: { id: workspaceId },
+      user: { id: inviterUserId },
+      actions: ActionType.INVITE,
+      details: `멤버 초대 - ${inviterUserName}님이 ${invitedUserName}님을 워크스페이스에 초대하였습니다. `,
+    });
+
+    return await this.auditLogRepository.save(newLog);
+  }
+
+  async deleteMemberLog(
+    workspaceId: number,
+    userId: number,
+    userName: string,
+    deletedUser: string
+  ): Promise<Audit_log> {
+    const newLog = this.auditLogRepository.create({
+      workspace: { id: workspaceId },
+      user: { id: userId },
+      actions: ActionType.DELETE,
+      details: `멤버 삭제 - ${userName}님이 ${deletedUser}님을 워크스페이스에서 내보냈습니다.`,
+    });
+
+    return await this.auditLogRepository.save(newLog);
+  }
+
+  async roleChangeLog(
+    workspaceId: number,
+    userId: number,
+    userName: string,
+    targetUser: string,
+    role: string
+  ): Promise<Audit_log> {
+    const newLog = this.auditLogRepository.create({
+      workspace: { id: workspaceId },
+      user: { id: userId },
+      actions: ActionType.ROLE_CHANGE,
+      details: `역할 변경 - ${userName}님이 ${targetUser}님의 역할을 ${role}로 변경했습니다.`,
+    });
+
+    return await this.auditLogRepository.save(newLog);
+  }
+
+  async createBoardLog(
+    workspaceId: number,
+    boardId: number,
+    boardName: string,
+    userId: number,
+    userName: string
+  ): Promise<Audit_log> {
+    const newLog = this.auditLogRepository.create({
+      workspace: { id: workspaceId },
+      user: { id: userId },
+      actions: ActionType.CREATE,
+      details: `보드 생성 - ${userName}님이 ${boardName} 보드를 생성하였습니다.`,
+    });
+
+    return await this.auditLogRepository.save(newLog);
+  }
+
+  async updateBoardLog(
+    workspaceId: number,
+    boardId: number,
+    boardName: string,
+    userId: number,
+    userName: string
+  ): Promise<Audit_log> {
+    const newLog = this.auditLogRepository.create({
+      workspace: { id: workspaceId },
+      user: { id: userId },
+      actions: ActionType.UPDATE,
+      details: `보드 수정 - ${userName}님이 ${boardName} 보드를 수정하였습니다.`,
+    });
+
+    return await this.auditLogRepository.save(newLog);
+  }
+
+  async deleteBoardLog(
+    workspaceId: number,
+    boardId: number,
+    boardName: string,
+    userId: number,
+    userName: string
+  ): Promise<Audit_log> {
+    const newLog = this.auditLogRepository.create({
+      workspace: { id: workspaceId },
+      user: { id: userId },
+      actions: ActionType.DELETE,
+      details: `보드 삭제 - ${userName}님이 ${boardName} 보드를 삭제하였습니다.`,
+    });
+
+    return await this.auditLogRepository.save(newLog);
+  }
+
+  // async createColumnLog() : Promise<Audit_log>{
+
+  // }
+
+  // async updateColumnLog(): Promise<Audit_log> {
+
+  // }
+
+  // async deleteColumnLog() : Promise<Audit_log>{
+
+  // }
+
+  // async createCardLog() : Promise<Audit_log>{
+
+  // }
+
+  // async updateCardLog
+
+  // async deleteCardLog
+}

--- a/src/board-columns/board-columns.module.ts
+++ b/src/board-columns/board-columns.module.ts
@@ -13,11 +13,24 @@ import { Board } from 'src/_common/entities/board.entity';
 import { Workspace } from 'src/_common/entities/workspace.entity';
 import { Workspace_Member } from 'src/_common/entities/workspace-member.entity';
 import { WorkspacesService } from 'src/workspaces/workspaces.service';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 
 @Module({
-  imports: [RedisCacheModule, TypeOrmModule.forFeature([Board_Column, Board, Workspace, Workspace_Member, User])],
+  imports: [
+    RedisCacheModule,
+    TypeOrmModule.forFeature([Board_Column, Board, Workspace, Workspace_Member, User, Audit_log]),
+  ],
   exports: [TypeOrmModule],
   controllers: [BoardColumnsController],
-  providers: [BoardColumnsService, BoardsService, WorkspacesService, JwtService, UsersService, MailService],
+  providers: [
+    BoardColumnsService,
+    BoardsService,
+    WorkspacesService,
+    JwtService,
+    UsersService,
+    MailService,
+    AuditLogsService,
+  ],
 })
 export class BoardColumnsModule {}

--- a/src/board-members/board-members.module.ts
+++ b/src/board-members/board-members.module.ts
@@ -17,11 +17,13 @@ import { Board_Column } from 'src/_common/entities/board-column.entity';
 import { BoardColumnsService } from 'src/board-columns/board-columns.service';
 import { CardsService } from 'src/cards/cards.service';
 import { Card } from 'src/_common/entities/card.entity';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 
 @Module({
   imports: [
     RedisCacheModule,
-    TypeOrmModule.forFeature([Board_Member, Board, Card, Workspace, Workspace_Member, User, Board_Column]),
+    TypeOrmModule.forFeature([Board_Member, Board, Card, Workspace, Workspace_Member, User, Board_Column, Audit_log]),
   ],
   controllers: [BoardMembersController],
   providers: [
@@ -33,6 +35,7 @@ import { Card } from 'src/_common/entities/card.entity';
     UsersService,
     MailService,
     BoardColumnsService,
+    AuditLogsService,
   ],
 })
 export class BoardMembersModule {}

--- a/src/board-messages/board-messages.module.ts
+++ b/src/board-messages/board-messages.module.ts
@@ -21,6 +21,8 @@ import { Board_Column } from 'src/_common/entities/board-column.entity';
 import { BoardColumnsService } from 'src/board-columns/board-columns.service';
 import { Card } from 'src/_common/entities/card.entity';
 import { CardsService } from 'src/cards/cards.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
 
 @Module({
   imports: [
@@ -34,6 +36,7 @@ import { CardsService } from 'src/cards/cards.service';
       User,
       Board_Member,
       Board_Column,
+      Audit_log,
     ]),
   ],
   exports: [TypeOrmModule],
@@ -48,6 +51,7 @@ import { CardsService } from 'src/cards/cards.service';
     MailService,
     BoardMembersService,
     BoardColumnsService,
+    AuditLogsService,
   ],
 })
 export class BoardMessagesModule {

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -50,7 +50,7 @@ export class BoardsController {
     @Res() res: Response,
     @GetUser() user: AccessPayload
   ): Promise<Object> {
-    const newBoard = await this.boardsService.CreateBoard(workspaceId, data.name, data.description, user.name);
+    const newBoard = await this.boardsService.CreateBoard(workspaceId, data.name, data.description, user.name, user.id);
     return res.status(HttpStatus.CREATED).json({ newBoard, message: '보드를 생성하였습니다.' });
   }
 
@@ -62,9 +62,10 @@ export class BoardsController {
     @Query('workspaceId') workspaceId: number,
     @Param('boardId') id: number,
     @Body() data: UpdateBoardDto,
-    @Res() res: Response
+    @Res() res: Response,
+    @GetUser() user: AccessPayload
   ) {
-    await this.boardsService.UpdateBoard(workspaceId, id, data.name, data.description);
+    await this.boardsService.UpdateBoard(workspaceId, id, data.name, data.description, user.id, user.name);
     return res.status(HttpStatus.OK).json({ message: '보드를 수정하였습니다.' });
   }
 
@@ -72,8 +73,13 @@ export class BoardsController {
   @Delete('/:boardId')
   @UseGuards(AuthGuard)
   @UseInterceptors(CheckAuthInterceptor)
-  async DeleteBoard(@Query('workspaceId') workspaceId: number, @Param('boardId') id: number, @Res() res: Response) {
-    await this.boardsService.DeleteBoard(workspaceId, id);
+  async DeleteBoard(
+    @Query('workspaceId') workspaceId: number,
+    @Param('boardId') id: number,
+    @Res() res: Response,
+    @GetUser() user: AccessPayload
+  ) {
+    await this.boardsService.DeleteBoard(workspaceId, id, user.id, user.name);
     return res.status(HttpStatus.OK).json({ message: '보드를 삭제하였습니다.' });
   }
 

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -12,11 +12,16 @@ import { WorkspacesService } from 'src/workspaces/workspaces.service';
 import { Workspace } from 'src/_common/entities/workspace.entity';
 import { Workspace_Member } from 'src/_common/entities/workspace-member.entity';
 import { Board_Column } from 'src/_common/entities/board-column.entity';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 
 @Module({
-  imports: [RedisCacheModule, TypeOrmModule.forFeature([Board, Board_Column, Workspace, Workspace_Member, User])],
+  imports: [
+    RedisCacheModule,
+    TypeOrmModule.forFeature([Board, Board_Column, Workspace, Workspace_Member, User, Audit_log]),
+  ],
   exports: [TypeOrmModule],
   controllers: [BoardsController],
-  providers: [BoardsService, WorkspacesService, JwtService, UsersService, MailService],
+  providers: [BoardsService, WorkspacesService, JwtService, UsersService, MailService, AuditLogsService],
 })
 export class BoardsModule {}

--- a/src/cards/cards.module.ts
+++ b/src/cards/cards.module.ts
@@ -17,11 +17,13 @@ import { Card } from 'src/_common/entities/card.entity';
 import { RedisCacheModule } from 'src/_common/cache/redis.module';
 import { UploadMultiMiddleware } from 'src/_common/middlewares/upload-multi-middleware';
 import { AuthGuard } from 'src/_common/security/auth.guard';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 
 @Module({
   imports: [
     RedisCacheModule,
-    TypeOrmModule.forFeature([Card, Board_Column, Board, Workspace, Workspace_Member, User]), // Card 엔티티 등록
+    TypeOrmModule.forFeature([Card, Board_Column, Board, Workspace, Workspace_Member, User, Audit_log]), // Card 엔티티 등록
   ],
   exports: [TypeOrmModule],
   controllers: [CardsController],
@@ -33,6 +35,7 @@ import { AuthGuard } from 'src/_common/security/auth.guard';
     UsersService,
     MailService,
     JwtService,
+    AuditLogsService,
   ],
 })
 export class CardsModule {

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -17,10 +17,12 @@ import { User } from 'src/_common/entities/user.entitiy';
 import { MailService } from 'src/_common/mail/mail.service';
 import { JwtService } from 'src/_common/security/jwt/jwt.service';
 import { RedisCacheModule } from 'src/_common/cache/redis.module';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 @Module({
   imports: [
     RedisCacheModule,
-    TypeOrmModule.forFeature([Card, Comment, Board_Column, Board, Workspace, Workspace_Member, User]), // Card 엔티티 등록
+    TypeOrmModule.forFeature([Card, Comment, Board_Column, Board, Workspace, Workspace_Member, User, Audit_log]), // Card 엔티티 등록
   ],
   controllers: [CommentsController],
   providers: [
@@ -32,6 +34,7 @@ import { RedisCacheModule } from 'src/_common/cache/redis.module';
     UsersService,
     MailService,
     JwtService,
+    AuditLogsService,
   ],
 })
 export class CommentsModule {}

--- a/src/memberships/memberships.module.ts
+++ b/src/memberships/memberships.module.ts
@@ -13,10 +13,20 @@ import { Workspace_Member } from 'src/_common/entities/workspace-member.entity';
 //import { ScheduleModule } from '@nestjs/schedule';
 import { RedisCacheModule } from 'src/_common/cache/redis.module';
 import { JwtStrategy } from 'src/_common/security/passport/passport.jwt.strategy';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 
 @Module({
-  imports: [RedisCacheModule, TypeOrmModule.forFeature([Membership, User, Workspace, Workspace_Member])],
+  imports: [RedisCacheModule, TypeOrmModule.forFeature([Membership, User, Workspace, Workspace_Member, Audit_log])],
   controllers: [MembershipsController],
-  providers: [MembershipsService, UsersService, JwtService, JwtStrategy, MailService, WorkspacesService],
+  providers: [
+    MembershipsService,
+    UsersService,
+    JwtService,
+    JwtStrategy,
+    MailService,
+    WorkspacesService,
+    AuditLogsService,
+  ],
 })
 export class MembershipsModule {}

--- a/src/mentions/mentions.module.ts
+++ b/src/mentions/mentions.module.ts
@@ -25,6 +25,8 @@ import { Workspace_Member } from 'src/_common/entities/workspace-member.entity';
 import { JwtService } from 'src/_common/security/jwt/jwt.service';
 import { BoardMembersService } from 'src/board-members/board-members.service';
 import { Board_Member } from 'src/_common/entities/board-member.entity';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
 
 @Module({
   imports: [
@@ -41,6 +43,7 @@ import { Board_Member } from 'src/_common/entities/board-member.entity';
       Workspace,
       Workspace_Member,
       Board_Member,
+      Audit_log,
     ]),
   ],
   exports: [TypeOrmModule],
@@ -58,6 +61,7 @@ import { Board_Member } from 'src/_common/entities/board-member.entity';
     UsersService,
     MailService,
     BoardMembersService,
+    AuditLogsService,
   ],
 })
 export class MentionsModule {}

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -14,9 +14,14 @@ import { Membership } from 'src/_common/entities/membership.entity';
 import { WorkspacesService } from 'src/workspaces/workspaces.service';
 import { RedisCacheModule } from 'src/_common/cache/redis.module';
 import { JwtStrategy } from 'src/_common/security/passport/passport.jwt.strategy';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 
 @Module({
-  imports: [RedisCacheModule, TypeOrmModule.forFeature([Payment, User, Workspace, Workspace_Member, Membership])],
+  imports: [
+    RedisCacheModule,
+    TypeOrmModule.forFeature([Payment, User, Workspace, Workspace_Member, Membership, Audit_log]),
+  ],
   controllers: [PaymentsController],
   providers: [
     PaymentsService,
@@ -26,6 +31,7 @@ import { JwtStrategy } from 'src/_common/security/passport/passport.jwt.strategy
     MailService,
     WorkspacesService,
     MembershipsService,
+    AuditLogsService,
   ],
 })
 export class PaymentsModule {}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -15,9 +15,14 @@ import { Payment } from 'src/_common/entities/payment.entity';
 import { Membership } from 'src/_common/entities/membership.entity';
 import { PaymentsService } from 'src/payments/payments.service';
 import { MembershipsService } from 'src/memberships/memberships.service';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
 
 @Module({
-  imports: [RedisCacheModule, TypeOrmModule.forFeature([User, Workspace, Workspace_Member, Payment, Membership])],
+  imports: [
+    RedisCacheModule,
+    TypeOrmModule.forFeature([User, Workspace, Workspace_Member, Payment, Membership, Audit_log]),
+  ],
   exports: [UsersModule],
   controllers: [UsersController],
   providers: [
@@ -28,6 +33,7 @@ import { MembershipsService } from 'src/memberships/memberships.service';
     WorkspacesService,
     PaymentsService,
     MembershipsService,
+    AuditLogsService,
   ],
 })
 export class UsersModule {

--- a/src/workspaces/workspaces.controller.ts
+++ b/src/workspaces/workspaces.controller.ts
@@ -94,8 +94,8 @@ export class WorkspacesController {
     @Param('userId') userId: number,
     @GetUser() user: AccessPayload
   ): Promise<IResult> {
-    const loginUser = user.id;
-    return await this.workspaceService.deleteWorkspaceMember(workspaceId, userId, loginUser);
+    const loginUser = user;
+    return await this.workspaceService.deleteWorkspaceMember(workspaceId, userId, loginUser.name, loginUser.id);
   }
 
   // 워크스페이스 멤버역할 변경
@@ -108,8 +108,8 @@ export class WorkspacesController {
     @Param('userId') userId: number,
     @GetUser() user: AccessPayload
   ): Promise<IResult> {
-    const loginUser = user.id;
-    return await this.workspaceService.setMemberRole(body, workspaceId, userId, loginUser);
+    const loginUser = user;
+    return await this.workspaceService.setMemberRole(body, workspaceId, userId, loginUser.name, loginUser.id);
   }
 
   // 워크스페이스 참여자 상태변경, 이메일에서 수락버튼 클릭 시 실행

--- a/src/workspaces/workspaces.module.ts
+++ b/src/workspaces/workspaces.module.ts
@@ -10,10 +10,12 @@ import { UsersService } from 'src/users/users.service';
 import { User } from 'src/_common/entities/user.entitiy';
 import { MailService } from 'src/_common/mail/mail.service';
 import { RedisCacheModule } from 'src/_common/cache/redis.module';
+import { Audit_log } from 'src/_common/entities/audit-log.entity';
+import { AuditLogsService } from 'src/audit-logs/audit-logs.service';
 
 @Module({
-  imports: [RedisCacheModule, TypeOrmModule.forFeature([Workspace, Workspace_Member, User])],
+  imports: [RedisCacheModule, TypeOrmModule.forFeature([Workspace, Workspace_Member, User, Audit_log])],
   controllers: [WorkspacesController],
-  providers: [WorkspacesService, UsersService, JwtStrategy, JwtService, MailService],
+  providers: [WorkspacesService, UsersService, JwtStrategy, JwtService, MailService, AuditLogsService],
 })
 export class WorkspacesModule {}


### PR DESCRIPTION
- 초기 보드, 보드컬럼, 카드를 관계설정을 해두었으나 단순 워크스페이스 로그 조회 용도라면 워크스페이스와 유저만 관계설정을 해두면 될 것 같아서 로직 수정